### PR TITLE
Hotfix on how uris are escaped

### DIFF
--- a/lib/dirty.js
+++ b/lib/dirty.js
@@ -1,0 +1,5 @@
+//  TODO: move this to template
+export function sparqlEscapeUri(value) {
+  console.log('Warning: using a monkey patched sparqlEscapeUri.');
+  return `<${value.replace(/[\\"<>]/g, (match) => `\\${match}`)}>`;
+}

--- a/lib/remote-data-object.js
+++ b/lib/remote-data-object.js
@@ -2,14 +2,9 @@ import {sparqlEscapeString, sparqlEscapeDateTime, uuid} from 'mu';
 import {querySudo as query, updateSudo as update} from '@lblod/mu-auth-sudo';
 import {SERVICE_URI} from "../app";
 import {NIE} from "@lblod/submission-form-helpers";
+import { sparqlEscapeUri } from './dirty';
 
 const DOWNLOAD_STATUS_READY_TO_BE_CASHED = 'http://lblod.data.gift/file-download-statuses/ready-to-be-cached';
-
-//  TODO: move this to template
-function sparqlEscapeUri( value ) {
-  console.log("Warning: using a monkey patched sparqlEscapeUri.");
-  return '<' + value.replace(/[\\"<>]/g, function(match) { return '\\' + match; }) + '>';
-};
 
 export class RemoteDataObject {
 

--- a/lib/remote-data-object.js
+++ b/lib/remote-data-object.js
@@ -1,9 +1,15 @@
-import {sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, uuid} from 'mu';
+import {sparqlEscapeString, sparqlEscapeDateTime, uuid} from 'mu';
 import {querySudo as query, updateSudo as update} from '@lblod/mu-auth-sudo';
 import {SERVICE_URI} from "../app";
 import {NIE} from "@lblod/submission-form-helpers";
 
 const DOWNLOAD_STATUS_READY_TO_BE_CASHED = 'http://lblod.data.gift/file-download-statuses/ready-to-be-cached';
+
+//  TODO: move this to template
+function sparqlEscapeUri( value ) {
+  console.log("Warning: using a monkey patched sparqlEscapeUri.");
+  return '<' + value.replace(/[\\"<>]/g, function(match) { return '\\' + match; }) + '>';
+};
 
 export class RemoteDataObject {
 

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeUri, uuid } from 'mu';
+import { uuid, sparqlEscapeUri } from 'mu';
 import { querySudo as query, updateSudo as update} from '@lblod/mu-auth-sudo';
 import { FILE_GRAPH, getFileContent, insertTtlFile, updateTtlFile } from './file-helpers';
 import ForkingStore from 'forking-store';


### PR DESCRIPTION
We used to escape `'` which was breaking the insert query in virtuoso for `nie:uri` of the remote data object. At the same time, not escaping `<` and `>` could lead to sparql injection.