### PR TITLE
Use cogs:Jobs and Tasks and integrate with job-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,21 +80,28 @@ Submits a submission document if it's valid.
 ### Model
 
 #### Automatic submission task
-A resource describing the status and progress of the processing of an automatic submission.
+
+A resource describing the status and operation of the subtask of processing an automatic submission job.
 
 ##### Class
-`melding:AutomaticSubmissionTask`
+
+`task:Task`
 
 ##### Properties
-The model is specified in the [README of the automatic submission service](https://github.com/lblod/automatic-submission-service#model).
+
+The model is specified in the [README of the job-controller-service](https://github.com/lblod/job-controller-service#task).
+
 ___
+
 #### Automatic submission task statuses
-Once the validation process starts, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/validating.
 
-On successful completion, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/successful-concept or http://lblod.data.gift/automatische-melding-statuses/successful-sent, depending whether the submission landed in 'concept' or in 'sent' status.
+Once the enrichment process starts, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
 
-On failure, the status is updated to http://lblod.data.gift/automatische-melding-statuses/failure.
+On successful completion, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/success. The resultsContainer is then linked to the inputContainer of the task, because no file has been created or modified, only triples in the database.
+
+On failure, the status is updated to http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error is written to the database and the error is linked to this failed task.
 ___
+
 #### Submission
 Submission to be validated and submitted. 
 

--- a/app.js
+++ b/app.js
@@ -1,15 +1,10 @@
 import { app, errorHandler } from 'mu';
 import bodyParser from 'body-parser';
 import flatten from 'lodash.flatten';
-import { TASK_READY_FOR_VALIDATION_STATUS,
-         TASK_ONGOING_STATUS,
-         TASK_SUCCESSFUL_CONCEPT_STATUS,
-         TASK_SUCCESSFUL_SENT_STATUS,
-         TASK_FAILURE_STATUS,
-         updateTaskStatus } from './lib/submission-task';
+import { updateTaskStatus } from './lib/submission-task';
 import { getSubmissionByTask, getSubmissionBySubmissionDocument, SUBMITABLE_STATUS, SENT_STATUS, CONCEPT_STATUS } from './lib/submission';
-
-export const SERVICE_URI = "http://lblod.data.gift/services/validate-submission-service";
+import * as env from './env.js';
+import { saveError } from './lib/utils.js';
 
 app.use(bodyParser.json({ type: function(req) { return /^application\/json/.test(req.get('content-type')); } }));
 
@@ -21,69 +16,52 @@ app.get('/', function(req, res) {
  * DELTA HANDLING
  */
 
-app.post('/delta', async function(req, res, next) {
-  const tasks = getAutomaticSubmissionTasks(req.body);
-  if (!tasks.length) {
-    console.log("Delta does not contain an automatic submission task with status 'ready-for-validation'. Nothing should happen.");
-    return res.status(204).send();
-  }
+app.post('/delta', async function (req, res, next) {
+  //We can already send a 200 back. The delta-notifier does not care about the result, as long as the request is closed.
+  res.status(200).send().end();
+  
+  try {
+    //Don't trust the delta-notifier, filter as best as possible. We just need the task that was created to get started.
+    const actualTaskUris = req.body
+      .map((changeset) => changeset.inserts)
+      .filter((inserts) => inserts.length > 0)
+      .flat()
+      .filter((insert) => insert.predicate.value === env.OPERATION_PREDICATE)
+      .filter((insert) => insert.object.value === env.VALIDATE_OPERATION)
+      .map((insert) => insert.subject.value);
 
-  for (let task of tasks) {
-    try {
-      await updateTaskStatus(task, TASK_ONGOING_STATUS);
-      const submission = await getSubmissionByTask(task);
+    debugger;
 
-      const handleAutomaticSubmission = async () => {
-        try {
-          const resultingStatus = await submission.process();
-          if(resultingStatus == SENT_STATUS){
-            await updateTaskStatus(task, TASK_SUCCESSFUL_SENT_STATUS);
-          }
-          else{
-            await updateTaskStatus(task, TASK_SUCCESSFUL_CONCEPT_STATUS);
-          }
-        } catch (e) {
-          await updateTaskStatus(task, TASK_FAILURE_STATUS);
-        }
-      };
-
-      handleAutomaticSubmission(); // async processing
-    } catch (e) {
-      console.log(`Something went wrong while handling deltas for automatic submission task ${task}`);
-      console.log(e);
+    for (const taskUri of actualTaskUris) {
       try {
-        await updateTaskStatus(task, TASK_FAILURE_STATUS);
-      } catch (e) {
-        console.log(`Failed to update state of task ${task} to failure state. Is the connection to the database broken?`);
+        await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
+        
+        const submission = await getSubmissionByTask(taskUri);
+        const resultingStatus = await submission.process();
+
+        await updateTaskStatus(
+          taskUri,
+          env.TASK_SUCCESS_STATUS,
+          undefined, //Potential errorURI
+          (resultingStatus === SENT_STATUS) ? env.TASK_SUCCESSFUL_SENT_STATUS : env.TASK_SUCCESSFUL_CONCEPT_STATUS
+        );
       }
-      return next(e);
+      catch (error) {
+        const message = `Something went wrong while enriching for task ${taskUri}`;
+        console.error(`${message}\n`, error.message);
+        console.error(error);
+        const errorUri = await saveError({ message, detail: error.message, });
+        await updateTaskStatus(taskUri, env.TASK_FAILURE_STATUS, errorUri);
+      }
     }
   }
-
-  return res.status(200).send({ data: tasks });
+  catch (error) {
+    const message = 'The task for enriching a submission could not even be started or finished due to an unexpected problem.';
+    console.error(`${message}\n`, error.message);
+    console.error(error);
+    await saveError({ message, detail: error.message, });
+  }
 });
-
-/**
- * Returns the automatic submission tasks that are ready for validation
- * from the delta message. An empty array if there are none.
- *
- * @param Object delta Message as received from the delta notifier
-*/
-function getAutomaticSubmissionTasks(delta) {
-  const inserts = flatten(delta.map(changeSet => changeSet.inserts));
-  return inserts.filter(isTriggerTriple).map(t => t.subject.value);
-}
-
-/**
- * Returns whether the passed triple is a trigger for the validation process
- *
- * @param Object triple Triple as received from the delta notifier
-*/
-function isTriggerTriple(triple) {
-  return triple.predicate.value == 'http://www.w3.org/ns/adms#status'
-    && triple.object.value == TASK_READY_FOR_VALIDATION_STATUS;
-};
-
 
 /*
  * SUBMISSION FORM ENDPOINTS
@@ -148,6 +126,5 @@ app.post('/submission-documents/:uuid/submit', async function(req, res, next) {
     return res.status(404).send({ title: `Submission ${uuid} not found` });
   }
 });
-
 
 app.use(errorHandler);

--- a/app.js
+++ b/app.js
@@ -35,7 +35,8 @@ app.post('/delta', async function (req, res, next) {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         
         const submission = await getSubmissionByTask(taskUri);
-        const resultingStatus = await submission.process();
+        const { status, logicalFileUri } = await submission.process();
+        const resultingStatus = status;
 
         let saveStatus;
         switch (resultingStatus) {
@@ -54,7 +55,8 @@ app.post('/delta', async function (req, res, next) {
           taskUri,
           env.TASK_SUCCESS_STATUS,
           undefined, //Potential errorURI
-          saveStatus
+          saveStatus,
+          logicalFileUri
         );
       }
       catch (error) {
@@ -119,7 +121,7 @@ app.post('/submission-documents/:uuid/submit', async function(req, res, next) {
         return res.status(422).send({ title: `Submission ${submission.uri} already submitted` });
       } else {
         await submission.updateStatus(SUBMITABLE_STATUS);
-        const newStatus = await submission.process();
+        const newStatus = (await submission.process()).status;
         if (newStatus == SENT_STATUS) {
           return res.status(204).send();
         } else {

--- a/env.js
+++ b/env.js
@@ -1,0 +1,53 @@
+export const CREATOR = "http://lblod.data.gift/services/validate-submission-service";
+
+export const TASK_ONGOING_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/busy';
+export const TASK_SUCCESS_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/success';
+export const TASK_FAILURE_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/failed';
+
+export const TASK_SUCCESSFUL_CONCEPT_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/successful-concept';
+export const TASK_SUCCESSFUL_SENT_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/successful-sent';
+
+export const OPERATION_PREDICATE = 'http://redpencil.data.gift/vocabularies/tasks/operation';
+export const VALIDATE_OPERATION = 'http://lblod.data.gift/id/jobs/concept/TaskOperation/validate';
+
+const PREFIX_TABLE = {
+  meb:          'http://rdf.myexperiment.org/ontologies/base/',
+  xsd:          'http://www.w3.org/2001/XMLSchema#',
+  pav:          'http://purl.org/pav/',
+  dct:          'http://purl.org/dc/terms/',
+  melding:      'http://lblod.data.gift/vocabularies/automatische-melding/',
+  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+  adms:         'http://www.w3.org/ns/adms#',
+  muAccount:    'http://mu.semte.ch/vocabularies/account/',
+  eli:          'http://data.europa.eu/eli/ontology#',
+  org:          'http://www.w3.org/ns/org#',
+  elod:         'http://linkedeconomy.org/ontology#',
+  nie:          'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  prov:         'http://www.w3.org/ns/prov#',
+  mu:           'http://mu.semte.ch/vocabularies/core/',
+  foaf:         'http://xmlns.com/foaf/0.1/',
+  nfo:          'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  ext:          'http://mu.semte.ch/vocabularies/ext/',
+  http:         'http://www.w3.org/2011/http#',
+  rpioHttp:     'http://redpencil.data.gift/vocabularies/http/',
+  dgftSec:      'http://lblod.data.gift/vocabularies/security/',
+  dgftOauth:    'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
+  wotSec:       'https://www.w3.org/2019/wot/security#',
+  task:         'http://redpencil.data.gift/vocabularies/tasks/',
+  asj:          'http://data.lblod.info/id/automatic-submission-job/',
+};
+
+export const PREFIXES = (() => {
+  const all = [];
+  for (const key in PREFIX_TABLE)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+})();
+
+export function getPrefixes(collOfPrefixes) {
+  const all = [];
+  for (const key of collOfPrefixes)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+}
+

--- a/env.js
+++ b/env.js
@@ -10,7 +10,7 @@ export const TASK_SUCCESSFUL_SENT_STATUS = 'http://lblod.data.gift/automatische-
 export const OPERATION_PREDICATE = 'http://redpencil.data.gift/vocabularies/tasks/operation';
 export const VALIDATE_OPERATION = 'http://lblod.data.gift/id/jobs/concept/TaskOperation/validate';
 
-const PREFIX_TABLE = {
+export const PREFIX_TABLE = {
   meb:          'http://rdf.myexperiment.org/ontologies/base/',
   xsd:          'http://www.w3.org/2001/XMLSchema#',
   pav:          'http://purl.org/pav/',
@@ -35,6 +35,7 @@ const PREFIX_TABLE = {
   wotSec:       'https://www.w3.org/2019/wot/security#',
   task:         'http://redpencil.data.gift/vocabularies/tasks/',
   asj:          'http://data.lblod.info/id/automatic-submission-job/',
+  dbpedia:      'http://dbpedia.org/ontology/',
 };
 
 export const PREFIXES = (() => {

--- a/env.js
+++ b/env.js
@@ -44,11 +44,3 @@ export const PREFIXES = (() => {
     all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
   return all.join('\n');
 })();
-
-export function getPrefixes(collOfPrefixes) {
-  const all = [];
-  for (const key of collOfPrefixes)
-    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
-  return all.join('\n');
-}
-

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -1,6 +1,7 @@
-import { updateSudo } from '@lblod/mu-auth-sudo';
+import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
 import { sparqlEscapeDateTime, sparqlEscapeInt, sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
+import * as env from '../env.js';
 
 /**
  * Returns the content of the given file
@@ -19,16 +20,18 @@ async function getFileContent(file) {
  * @param string ttl Turtle to write to the file
 */
 async function insertTtlFile(submissionDocument, content) {
-  const id = uuid();
-  const filename = `${id}.ttl`;
+  const logicalId = uuid();
+  const physicalId = uuid();
+  const filename = `${physicalId}.ttl`;
   const path = `/share/submissions/${filename}`;
-  const uri = path.replace('/share/', 'share://');
-  const now = new Date();
+  const physicalUri = path.replace('/share/', 'share://');
+  const logicalUri = env.PREFIX_TABLE.asj.concat(logicalId);
+  const nowSparql = sparqlEscapeDateTime(new Date());
 
   try {
     await fs.writeFile(path, content, 'utf-8');
   } catch (e) {
-    console.log(`Failed to write TTL to file <${uri}>.`);
+    console.log(`Failed to write TTL to file <${path}>.`);
     throw e;
   }
 
@@ -38,50 +41,65 @@ async function insertTtlFile(submissionDocument, content) {
 
     //Sudo required because may be called both from automatic-submission or user
     await updateSudo(`
-      PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-
+      ${env.PREFIXES}
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} a nfo:FileDataObject ;
-                                  mu:uuid ${sparqlEscapeString(id)};
-                                  nfo:fileName ${sparqlEscapeString(filename)} ;
-                                  dct:creator <http://lblod.data.gift/services/validate-submission-service>;
-                                  dct:created ${sparqlEscapeDateTime(now)};
-                                  dct:modified ${sparqlEscapeDateTime(now)};
-                                  dct:format "text/turtle";
-                                  nfo:fileSize ${sparqlEscapeInt(fileSize)};
-                                  dbpedia:fileExtension "ttl" .
+          ${sparqlEscapeUri(physicalUri)}
+            a nfo:FileDataObject ;
+            mu:uuid ${sparqlEscapeString(physicalId)} ;
+            nie:dataSource asj:${logicalId} ;
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" .
+
+          asj:${logicalId}
+            a nfo:FileDataObject;
+            mu:uuid ${sparqlEscapeString(logicalId)} ;
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" . 
         }
       }
       WHERE {
         GRAPH ?g {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
-      }
-`);
+      }`);
 
   } catch (e) {
-    console.log(`Failed to write TTL resource <${uri}> to triplestore.`);
+    console.log(`Failed to write TTL resource <${logicalUri}> to triplestore.`);
     throw e;
   }
 
-  return uri;
+  return logicalUri;
 }
 
-async function updateTtlFile(submissionDocument, uri, content) {
-  const path = uri.replace('share://', '/share/');
+async function updateTtlFile(submissionDocument, logicalFileUri, content) {
+  const response = await querySudo(`
+    ${env.getPrefixes(['nie', 'ext'])}
+    SELECT ?physicalUri WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
+        ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
+      }
+    }
+  `);
+  const physicalUri = response.results.bindings[0].physicalUri.value;
+  const path = physicalUri.replace('share://', '/share/');
   const now = new Date();
 
   try {
     await fs.writeFile(path, content, 'utf-8');
   } catch (e) {
-    console.log(`Failed to write TTL to file <${uri}>.`);
+    console.log(`Failed to write TTL to file <${path}>.`);
     throw e;
   }
 
@@ -92,26 +110,27 @@ async function updateTtlFile(submissionDocument, uri, content) {
     //Sudo required because may be called both from automatic-submission or user
     await updateSudo(`
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-      DELETE WHERE {
+      DELETE {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} dct:modified ?modified ;
-                                  nfo:fileSize ?fileSize .
+          ${sparqlEscapeUri(physicalUri)}
+            dct:modified ?modified ;
+            nfo:fileSize ?fileSize .
+          ${sparqlEscapeUri(logicalFileUri)}
+            dct:modified ?modified ;
+            nfo:fileSize ?fileSize .
         }
       }
-
-      ;
-
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} dct:modified ${sparqlEscapeDateTime(now)} ;
-                                  nfo:fileSize ${sparqlEscapeInt(fileSize)} .
+          ${sparqlEscapeUri(physicalUri)}
+            dct:modified ${sparqlEscapeDateTime(now)} ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} .
+          ${sparqlEscapeUri(logicalFileUri)}
+            dct:modified ${sparqlEscapeDateTime(now)} ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} .
         }
       }
       WHERE {
@@ -119,10 +138,10 @@ async function updateTtlFile(submissionDocument, uri, content) {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
-`);
+  `);
 
   } catch (e) {
-    console.log(`Failed to update TTL resource <${uri}> in triplestore.`);
+    console.log(`Failed to update TTL resource <${logicalFileUri}> in triplestore.`);
     throw e;
   }
 }

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -84,7 +84,7 @@ async function insertTtlFile(submissionDocument, content) {
 
 async function updateTtlFile(submissionDocument, logicalFileUri, content) {
   const response = await querySudo(`
-    ${env.getPrefixes(['nie', 'ext'])}
+    ${env.PREFIXES}
     SELECT ?physicalUri WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .

--- a/lib/remote-data-object.js
+++ b/lib/remote-data-object.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeString, sparqlEscapeDateTime, uuid, sparqlEscapeUri } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { SERVICE_URI } from '../app';
+import * as env from '../env.js';
 import { NIE } from '@lblod/submission-form-helpers';
 
 const DOWNLOAD_STATUS_READY_TO_BE_CASHED = 'http://lblod.data.gift/file-download-statuses/ready-to-be-cached';
@@ -114,7 +114,7 @@ INSERT DATA {
     this.address = address;
     this.uuid = uuid();
     this.status = DOWNLOAD_STATUS_READY_TO_BE_CASHED;
-    this.creator = SERVICE_URI;
+    this.creator = env.CREATOR;
     this.created = new Date();
     this.modified = new Date();
   }

--- a/lib/remote-data-object.js
+++ b/lib/remote-data-object.js
@@ -50,10 +50,13 @@ export class RemoteDataObject {
       PREFIX nie:   <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
       PREFIX prov:  <http://www.w3.org/ns/prov#>
       PREFIX melding:   <http://lblod.data.gift/vocabularies/automatische-melding/>
+      PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+
       ASK {
-       ?submission nie:hasPart ${sparqlEscapeUri(remoteDataObject)}.
-       ?task prov:generated ?submission;
-         a melding:AutomaticSubmissionTask.
+        ?s nie:hasPart ${sparqlEscapeUri(remoteDataObject)}.
+        ?fo prov:generated ?s.
+        ?fo a <http://vocab.deri.ie/cogs#Job>;
+          task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/automaticSubmissionFlow>.
       }
    `;
     const result = await query(queryStr);

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -17,7 +17,7 @@ const FORM_FILE_TYPE = 'http://data.lblod.gift/concepts/form-file-type';
  * @return {string} TTL with form description for the given submission document
  */
 function getFormTtl(submissionDocument) {
-  return getPart(submissionDocument, FORM_FILE_TYPE);
+  return getPartNoLogical(submissionDocument, FORM_FILE_TYPE);
 }
 
 /**
@@ -90,22 +90,19 @@ async function getHarvestedData(submissionDocument) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT ?ttlFile
+    SELECT DISTINCT ?physicalFile
     WHERE {
       GRAPH ?g {
-        ?submission dct:subject ${sparqlEscapeUri(submissionDocument)} ;
-                    nie:hasPart ?remoteFile .
-        ?localHtmlDownload nie:dataSource ?remoteFile .
-        ?ttlFile nie:dataSource ?localHtmlDownload .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
+        ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
+        ?physicalFile nie:dataSource ?logicalFile .
       }
     }
   `);
 
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['ttlFile'].value;
+    const file = result.results.bindings[0]['physicalFile'].value;
     return await getFileContent(file);
-  } else {
-    return null;
   }
 }
 
@@ -139,6 +136,40 @@ function getRemovals(submissionDocument) {
  * @return {string} Content of the related file
 */
 async function getPart(submissionDocument, fileType) {
+  const result = await query(`
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+    SELECT DISTINCT ?physicalFile
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
+        ?physicalFile nie:dataSource ?logicalFile .
+      }
+
+      ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
+    }
+  `);
+
+  if (result.results.bindings.length) {
+    const file = result.results.bindings[0]['physicalFile'].value;
+    return await getFileContent(file);
+  } else {
+    console.log(`No file of type ${fileType} found for submission document ${submissionDocument}`);
+    return null;
+  }
+}
+
+/**
+ * Get the content of a file of the given file type that is related to the given submission document
+ * This function does not do it properly according to the file service. There is no logical file accompanying the physical file, only the physical file. This is to maintain compatibility with other services in the flow for now.
+ *
+ * @param {string} submissionDocument URI of the submitted document to get the related file for
+ * @param {string} fileType URI of the type of the related file
+ * @return {string} Content of the related file
+*/
+async function getPartNoLogical(submissionDocument, fileType) {
   const result = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -64,6 +64,7 @@ async function updateDocument(submissionDocument, { additions, removals }) {
 async function saveFormTriples(submissionDocument, triples) {
   const nt = triples.map(t => t.toNT()).join('\n');
   const file = await saveFormData(submissionDocument, nt);
+  return file;
 }
 
 export {
@@ -249,15 +250,15 @@ async function savePart(submissionDocument, content, fileType) {
   `);
 
   if (!result.results.bindings.length) {
-    const file = await insertTtlFile(submissionDocument, content);
+    const logicalFileUri = await insertTtlFile(submissionDocument, content);
     await update(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(file)} .
-          ${sparqlEscapeUri(file)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
+          ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
         GRAPH ?g {
@@ -265,10 +266,10 @@ async function savePart(submissionDocument, content, fileType) {
         }
       }
     `);
-    return file;
+    return logicalFileUri;
   } else {
     const file = result.results.bindings[0]['file'].value;
-    await updateTtlFile(submissionDocument,  file, content);
+    await updateTtlFile(submissionDocument, file, content);
     return file;
   }
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -27,7 +27,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, l
   }
 
   const statusUpdateQuery = `
-    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu', 'ext'])}
+    ${env.PREFIXES}
     DELETE {
       GRAPH ?g {
         ${taskUriSparql}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -1,55 +1,48 @@
-import { sparqlEscapeUri } from 'mu';
-import { updateSudo as update } from '@lblod/mu-auth-sudo';
-
-const TASK_READY_FOR_VALIDATION_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/ready-for-validation';
-const TASK_ONGOING_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/validating';
-const TASK_SUCCESSFUL_CONCEPT_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/successful-concept';
-const TASK_SUCCESSFUL_SENT_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/successful-sent';
-const TASK_FAILURE_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/failure';
+import * as mu from 'mu';
+import * as mas from '@lblod/mu-auth-sudo';
+import * as env from '../env.js';
 
 /**
- * Updates the state of the given task to the specified status
+ * Updates the state of the given task to the specified status with potential error message or resultcontainer file
  *
  * @param string taskUri URI of the task
  * @param string status URI of the new status
+ * @param string or undefined URI of the error that needs to be attached
 */
-async function updateTaskStatus(taskUri, status) {
-  const q = `
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
+export async function updateTaskStatus(taskUri, status, errorUri, extraStatus) {
+  const taskUriSparql = mu.sparqlEscapeUri(taskUri);
+  const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
+  const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
 
+  const statusUpdateQuery = `
+    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu', 'ext'])}
     DELETE {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          dct:modified ?oldModified .
       }
     }
-
-    ;
-
     INSERT {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ${sparqlEscapeUri(status)} .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} a melding:AutomaticSubmissionTask .
+        ${taskUriSparql}
+          adms:status ${mu.sparqlEscapeUri(status)} ;
+          ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultsContainer ?inputContainer ;` : ''}
+          dct:modified ${nowSparql} .
+
+        ${(status === env.TASK_SUCCESS_STATUS && extraStatus) ? `?inputContainer ext:additionalStatus ${mu.sparqlEscapeUri(extraStatus)} .` : ''}
       }
     }
-
+    WHERE {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
+          dct:modified ?oldModified .
+      }
+    }
   `;
-
-  await update(q);
+  await mas.updateSudo(statusUpdateQuery);
 }
 
-export {
-  TASK_SUCCESSFUL_CONCEPT_STATUS,
-  TASK_SUCCESSFUL_SENT_STATUS,
-  TASK_READY_FOR_VALIDATION_STATUS,
-  TASK_ONGOING_STATUS,
-  TASK_FAILURE_STATUS,
-  updateTaskStatus
-}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -9,10 +9,22 @@ import * as env from '../env.js';
  * @param string status URI of the new status
  * @param string or undefined URI of the error that needs to be attached
 */
-export async function updateTaskStatus(taskUri, status, errorUri, extraStatus) {
+export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, logicalFileUri) {
   const taskUriSparql = mu.sparqlEscapeUri(taskUri);
   const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
+
+  let resultContainerTriples = '';
+  let resultContainerUuid = '';
+  if (logicalFileUri) {
+    resultContainerUuid = mu.uuid();
+    resultContainerTriples = `
+      asj:${resultContainerUuid}
+        a nfo:DataContainer ;
+        mu:uuid ${mu.sparqlEscapeString(resultContainerUuid)} ;
+        task:hasFile ${mu.sparqlEscapeUri(logicalFileUri)} .
+    `;
+  }
 
   const statusUpdateQuery = `
     ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu', 'ext'])}
@@ -27,18 +39,19 @@ export async function updateTaskStatus(taskUri, status, errorUri, extraStatus) {
       GRAPH ?g {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
+          ${resultContainerUuid ? `task:resultsContainer asj:${resultContainerUuid} ;` : ''}
           ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
-          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultsContainer ?inputContainer ;` : ''}
           dct:modified ${nowSparql} .
 
         ${(status === env.TASK_SUCCESS_STATUS && extraStatus) ? `?inputContainer ext:additionalStatus ${mu.sparqlEscapeUri(extraStatus)} .` : ''}
+
+        ${resultContainerTriples}
       }
     }
     WHERE {
       GRAPH ?g {
         ${taskUriSparql}
           adms:status ?oldStatus ;
-          ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
           dct:modified ?oldModified .
       }
     }

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -132,7 +132,7 @@ class Submission {
 
 async function getSubmissionByTask(taskUri) {
   const response = await query(`
-    ${env.getPrefixes(['task', 'dct', 'prov', 'adms'])}
+    ${env.PREFIXES}
     SELECT ?submission ?submissionDocument ?status
     WHERE {
       GRAPH ?g {

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -84,13 +84,13 @@ class Submission {
         }
       }
 
-      await saveFormTriples(this.submittedResource, triples);
+      const logicalFileUri = await saveFormTriples(this.submittedResource, triples);
 
       if (targetStatus) {
         await this.updateStatus(targetStatus);
       }
 
-      return targetStatus == null ? currentStatus : targetStatus;
+      return { status: targetStatus == null ? currentStatus : targetStatus, logicalFileUri };
     } catch (e) {
       console.log(`Something went wrong while processing submission ${this.uri}`);
       console.log(e);

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -4,6 +4,7 @@ import FormBuilder from './form-builder';
 import { getFormTtl, getSourceTtl, getMetaTtl, updateDocument, saveFormTriples } from './submission-form';
 import fs from 'fs';
 import { RemoteDataObject } from './remote-data-object';
+import * as env from '../env.js';
 
 const CONCEPT_STATUS = 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
 const SUBMITABLE_STATUS = 'http://lblod.data.gift/concepts/f6330856-e261-430f-b949-8e510d20d0ff';
@@ -130,36 +131,30 @@ class Submission {
 }
 
 async function getSubmissionByTask(taskUri) {
-  const q = `
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-    PREFIX dct: <http://purl.org/dc/terms/>
-
-    SELECT ?submission ?status ?submittedResource
+  const response = await query(`
+    ${env.getPrefixes(['task', 'dct', 'prov', 'adms'])}
+    SELECT ?submission ?submissionDocument ?status
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} prov:generated ?submission ;
-           a melding:AutomaticSubmissionTask .
-        ?submission dct:subject ?submittedResource ;
-           adms:status ?status ;
-           nie:hasPart ?remoteFile .
+        ${sparqlEscapeUri(taskUri)}
+          a task:Task ;
+          dct:isPartOf ?job .
+        ?job prov:generated ?submission .
+        ?submission
+          dct:subject ?submissionDocument ;
+          adms:status ?status .
       }
     } LIMIT 1
-  `;
+  `);
 
-  const result = await query(q);
-
-  if (result.results.bindings.length) {
-    const binding = result.results.bindings[0];
+  const bindings = response?.results?.bindings;
+  if (bindings && bindings.length > 0) {
+    const binding = bindings[0];
     return new Submission({
-      uri: binding['submission'].value,
-      status: binding['status'].value,
-      submittedResource: binding['submittedResource'].value
+      uri: binding.submission.value,
+      status: binding.status.value,
+      submittedResource: binding.submissionDocument.value
     });
-  } else {
-    return null;
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,38 @@
+import * as mas from '@lblod/mu-auth-sudo';
+import * as mu from 'mu';
+import * as env from '../env.js';
+
+export async function saveError({message, detail, reference}) {
+  if (!message)
+    throw 'Error needs a message describing what went wrong.';
+  const id = mu.uuid();
+  const uri = `http://data.lblod.info/errors/${id}`;
+  const q = `
+    PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct:  <http://purl.org/dc/terms/>
+    PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+    INSERT DATA {
+      GRAPH <http://mu.semte.ch/graphs/error> {
+        ${mu.sparqlEscapeUri(uri)}
+          a oslc:Error ;
+          mu:uuid ${mu.sparqlEscapeString(id)} ;
+          dct:subject ${mu.sparqlEscapeString('Automatic Submission Service')} ;
+          oslc:message ${mu.sparqlEscapeString(message)} ;
+          dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
+          ${reference ? `dct:references ${mu.sparqlEscapeUri(reference)} ;` : ''}
+          ${detail ? `oslc:largePreview ${mu.sparqlEscapeString(detail)} ;` : ''}
+          dct:creator ${mu.sparqlEscapeUri(env.CREATOR)} .
+      }
+    }
+   `;
+  try {
+    await mas.updateSudo(q);
+    return uri;
+  }
+  catch (e) {
+    console.warn(`[WARN] Something went wrong while trying to store an error.\nMessage: ${e}\nQuery: ${q}`);
+  }
+}
+


### PR DESCRIPTION
This PR makes this service integrate with the job-controller-service. It listens for scheduled tasks with operation "validate" and starts the process from the data in the inputContainer of the task. Some function have been removed or rewritten because of this. When the task is finished, its status is set to "success" and the resultsContainer will point to the inputContainer, because no file has been created or modified, only triples in the database. Ideally, we should have a resultsContainer that can point to individuals in the data as well.

Some constants have also been moved to a separate file and some imports are now done differently.
