### PR TITLE
Reverting to previous file linking

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@ app.post('/delta', async function (req, res, next) {
         );
       }
       catch (error) {
-        const message = `Something went wrong while enriching for task ${taskUri}`;
+        const message = `Something went wrong while validating for task ${taskUri}`;
         console.error(`${message}\n`, error.message);
         console.error(error);
         const errorUri = await saveError({ message, detail: error.message, });

--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ app.post('/delta', async function (req, res, next) {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         
         const submission = await getSubmissionByTask(taskUri);
-        const { status, logicalFileUri } = await submission.process();
+        const { status, logicalFile } = await submission.process();
         const resultingStatus = status;
 
         let saveStatus;
@@ -56,7 +56,7 @@ app.post('/delta', async function (req, res, next) {
           env.TASK_SUCCESS_STATUS,
           undefined, //Potential errorURI
           saveStatus,
-          logicalFileUri
+          logicalFile
         );
       }
       catch (error) {

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -79,7 +79,7 @@ async function insertTtlFile(submissionDocument, content) {
     throw e;
   }
 
-  return logicalUri;
+  return { logicalFile: logicalUri, physicalFile: physicalUri };
 }
 
 async function updateTtlFile(submissionDocument, logicalFileUri, content) {

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -17,7 +17,7 @@ const FORM_FILE_TYPE = 'http://data.lblod.gift/concepts/form-file-type';
  * @return {string} TTL with form description for the given submission document
  */
 function getFormTtl(submissionDocument) {
-  return getPartNoLogical(submissionDocument, FORM_FILE_TYPE);
+  return getPart(submissionDocument, FORM_FILE_TYPE);
 }
 
 /**
@@ -63,8 +63,7 @@ async function updateDocument(submissionDocument, { additions, removals }) {
  */
 async function saveFormTriples(submissionDocument, triples) {
   const nt = triples.map(t => t.toNT()).join('\n');
-  const file = await saveFormData(submissionDocument, nt);
-  return file;
+  return saveFormData(submissionDocument, nt);
 }
 
 export {
@@ -94,9 +93,8 @@ async function getHarvestedData(submissionDocument) {
     SELECT DISTINCT ?physicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
-        ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
-        ?physicalFile nie:dataSource ?logicalFile .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        ?physicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
       }
     }
   `);
@@ -142,56 +140,21 @@ async function getPart(submissionDocument, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?physicalFile
+    SELECT DISTINCT ?physicalFile ?logicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
-        ?physicalFile nie:dataSource ?logicalFile .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        OPTIONAL { ?physicalFile nie:dataSource ?logicalFile . }
       }
-
-      ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
+      ?physicalFile dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
 
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['physicalFile'].value;
-    return await getFileContent(file);
+    const physicalFile = result.results.bindings[0]?.physicalFile?.value;
+    if (physicalFile) return getFileContent(physicalFile); 
   } else {
     console.log(`No file of type ${fileType} found for submission document ${submissionDocument}`);
-    return null;
-  }
-}
-
-/**
- * Get the content of a file of the given file type that is related to the given submission document
- * This function does not do it properly according to the file service. There is no logical file accompanying the physical file, only the physical file. This is to maintain compatibility with other services in the flow for now.
- *
- * @param {string} submissionDocument URI of the submitted document to get the related file for
- * @param {string} fileType URI of the type of the related file
- * @return {string} Content of the related file
-*/
-async function getPartNoLogical(submissionDocument, fileType) {
-  const result = await query(`
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-
-    SELECT DISTINCT ?file
-    WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
-      }
-
-      ?file dct:type ${sparqlEscapeUri(fileType)} .
-    }
-  `);
-
-  if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['file'].value;
-    return await getFileContent(file);
-  } else {
-    console.log(`No file of type ${fileType} found for submission document ${submissionDocument}`);
-    return null;
   }
 }
 
@@ -240,25 +203,28 @@ async function savePart(submissionDocument, content, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?file
+    SELECT DISTINCT ?logicalFile ?physicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        ?physicalFile
+          nie:dataSource ?logicalFile ;
+          dct:type ${sparqlEscapeUri(fileType)} .
       }
-      ?file dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
 
   if (!result.results.bindings.length) {
-    const logicalFileUri = await insertTtlFile(submissionDocument, content);
+    const { logicalFile, physicalFile } = await insertTtlFile(submissionDocument, content);
     await update(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
-          ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(physicalFile)} .
+          ${sparqlEscapeUri(logicalFile)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(physicalFile)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
         GRAPH ?g {
@@ -266,10 +232,11 @@ async function savePart(submissionDocument, content, fileType) {
         }
       }
     `);
-    return logicalFileUri;
+    return { logicalFile, physicalFile };
   } else {
-    const file = result.results.bindings[0]['file'].value;
-    await updateTtlFile(submissionDocument, file, content);
-    return file;
+    const logicalFile = result.results.bindings[0]['logicalFile'].value;
+    const physicalFile = results.results.bindings[0]['physicalFile'].value;
+    await updateTtlFile(submissionDocument, logicalFile, content);
+    return { logicalFile, physicalFile };
   }
 }

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -235,7 +235,7 @@ async function savePart(submissionDocument, content, fileType) {
     return { logicalFile, physicalFile };
   } else {
     const logicalFile = result.results.bindings[0]['logicalFile'].value;
-    const physicalFile = results.results.bindings[0]['physicalFile'].value;
+    const physicalFile = result.results.bindings[0]['physicalFile'].value;
     await updateTtlFile(submissionDocument, logicalFile, content);
     return { logicalFile, physicalFile };
   }

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -84,13 +84,13 @@ class Submission {
         }
       }
 
-      const logicalFileUri = await saveFormTriples(this.submittedResource, triples);
+      const { logicalFile, physicalFile } = await saveFormTriples(this.submittedResource, triples);
 
       if (targetStatus) {
         await this.updateStatus(targetStatus);
       }
 
-      return { status: targetStatus == null ? currentStatus : targetStatus, logicalFileUri };
+      return { status: targetStatus == null ? currentStatus : targetStatus, logicalFile };
     } catch (e) {
       console.log(`Something went wrong while processing submission ${this.uri}`);
       console.log(e);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ export async function saveError({message, detail, reference}) {
         ${mu.sparqlEscapeUri(uri)}
           a oslc:Error ;
           mu:uuid ${mu.sparqlEscapeString(id)} ;
-          dct:subject ${mu.sparqlEscapeString('Automatic Submission Service')} ;
+          dct:subject ${mu.sparqlEscapeString('Validate Submission Service')} ;
           oslc:message ${mu.sparqlEscapeString(message)} ;
           dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
           ${reference ? `dct:references ${mu.sparqlEscapeUri(reference)} ;` : ''}


### PR DESCRIPTION
In a previous version, the imported file was linked to the Submitted Document by means of a physical file. Due to the introduction of the cogs:Job model and the interoperability with the job-controller and the dashboard, the Submitted Document was linked to a logical file, just like the task for this service.

We are now rolling back that decision because of backwards compatibility problems, but while keeping the interoperability with the dashboard and the job-controller.