### PR TITLE
Only insert in one graph

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.post('/delta', async function (req, res, next) {
       try {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         
-        const submission = await getSubmissionByTask(taskUri);
+        const submission = await getSubmissionByTask(taskUri, { req });
         const { status, logicalFileUri } = await submission.process();
         const resultingStatus = status;
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+import * as env from 'env-var';
+
+export const GRAPH_TEMPLATE = env.get('GRAPH_TEMPLATE')
+  .example('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .default('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(`The GRAPH_TEMPLATE environment variable ${GRAPH_TEMPLATE} does not contain a ~ORGANIZATION_ID~.`);
+})();

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -19,7 +19,7 @@ async function getFileContent(file) {
  *
  * @param string ttl Turtle to write to the file
 */
-async function insertTtlFile(submissionDocument, content) {
+async function insertTtlFile(submissionDocument, content, graph) {
   const logicalId = uuid();
   const physicalId = uuid();
   const filename = `${physicalId}.ttl`;
@@ -43,7 +43,7 @@ async function insertTtlFile(submissionDocument, content) {
     await updateSudo(`
       ${env.PREFIXES}
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(physicalUri)}
             a nfo:FileDataObject ;
             mu:uuid ${sparqlEscapeString(physicalId)} ;
@@ -69,7 +69,7 @@ async function insertTtlFile(submissionDocument, content) {
         }
       }
       WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }`);
@@ -82,11 +82,11 @@ async function insertTtlFile(submissionDocument, content) {
   return logicalUri;
 }
 
-async function updateTtlFile(submissionDocument, logicalFileUri, content) {
+async function updateTtlFile(submissionDocument, logicalFileUri, content, graph) {
   const response = await querySudo(`
     ${env.PREFIXES}
     SELECT ?physicalUri WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
       }
@@ -114,7 +114,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       DELETE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(physicalUri)}
             dct:modified ?modified ;
             nfo:fileSize ?fileSize .
@@ -124,7 +124,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
         }
       }
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(physicalUri)}
             dct:modified ${sparqlEscapeDateTime(now)} ;
             nfo:fileSize ${sparqlEscapeInt(fileSize)} .
@@ -134,7 +134,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
         }
       }
       WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }

--- a/lib/remote-data-object.js
+++ b/lib/remote-data-object.js
@@ -23,7 +23,7 @@ export class RemoteDataObject {
    *
    * @param triples that could contain candidates for `RemoteDataObject`.
    */
-  static async process(triples) {
+  static async process(triples, graph) {
     const candidates = triples.filter(t => t.predicate.value === NIE('url').value)
                               .map(({subject, object}) => Object.create({
                                 uri: subject.value,
@@ -32,7 +32,7 @@ export class RemoteDataObject {
 
     const toReSchedule = [];
     for(const candidate of candidates){
-      if(!(await RemoteDataObject.wasCreatedByAutomaticSubmission(candidate.uri))){
+      if(!(await RemoteDataObject.wasCreatedByAutomaticSubmission(candidate.uri, graph))){
         toReSchedule.push(candidate);
       }
     }
@@ -45,7 +45,7 @@ export class RemoteDataObject {
   }
 
 
-  static async wasCreatedByAutomaticSubmission( remoteDataObject ){
+  static async wasCreatedByAutomaticSubmission(remoteDataObject, graph) {
     const queryStr = `
       PREFIX nie:   <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
       PREFIX prov:  <http://www.w3.org/ns/prov#>
@@ -53,10 +53,12 @@ export class RemoteDataObject {
       PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 
       ASK {
-        ?s nie:hasPart ${sparqlEscapeUri(remoteDataObject)}.
-        ?fo prov:generated ?s.
-        ?fo a <http://vocab.deri.ie/cogs#Job>;
-          task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/automaticSubmissionFlow>.
+        GRAPH ${sparqlEscapeUri(graph)} {
+          ?s nie:hasPart ${sparqlEscapeUri(remoteDataObject)}.
+          ?fo prov:generated ?s.
+          ?fo a <http://vocab.deri.ie/cogs#Job>;
+            task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/automaticSubmissionFlow>.
+        }
       }
    `;
     const result = await query(queryStr);
@@ -112,7 +114,7 @@ INSERT DATA {
     }
   }
 
-  constructor({uri, address}) {
+  constructor({uri, address, graph}) {
     this.uri = uri;
     this.address = address;
     this.uuid = uuid();
@@ -120,6 +122,7 @@ INSERT DATA {
     this.creator = env.CREATOR;
     this.created = new Date();
     this.modified = new Date();
+    this.graph = graph;
   }
 
   /**

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -93,9 +93,8 @@ async function getHarvestedData(submissionDocument, graph) {
     SELECT DISTINCT ?physicalFile
     WHERE {
       GRAPH ${sparqlEscapeUri(graph)} {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
-        ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
-        ?physicalFile nie:dataSource ?logicalFile .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        ?physicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
       }
     }
   `);

--- a/lib/submission-form.js
+++ b/lib/submission-form.js
@@ -16,8 +16,8 @@ const FORM_FILE_TYPE = 'http://data.lblod.gift/concepts/form-file-type';
  * @param {string} submissionDocument URI of the submitted document to get the form description for
  * @return {string} TTL with form description for the given submission document
  */
-function getFormTtl(submissionDocument) {
-  return getPartNoLogical(submissionDocument, FORM_FILE_TYPE);
+function getFormTtl(submissionDocument, graph) {
+  return getPartNoLogical(submissionDocument, FORM_FILE_TYPE, graph);
 }
 
 /**
@@ -27,10 +27,10 @@ function getFormTtl(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the source data for
  * @return {string} TTL with source data for the given submission document
 */
-async function getSourceTtl(submissionDocument) {
-  const source = await getHarvestedData(submissionDocument);
-  const additions = await getAdditions(submissionDocument);
-  const removals = await getRemovals(submissionDocument);
+async function getSourceTtl(submissionDocument, sumbissionGraph) {
+  const source = await getHarvestedData(submissionDocument, sumbissionGraph);
+  const additions = await getAdditions(submissionDocument, sumbissionGraph);
+  const removals = await getRemovals(submissionDocument, sumbissionGraph);
 
   // merge source, additions and removals
   const forkingStore = new ForkingStore();
@@ -45,25 +45,25 @@ async function getSourceTtl(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the meta data for
  * @return {string} TTL with meta data for the given submission document
 */
-function getMetaTtl(submissionDocument) {
-  return getPart(submissionDocument, META_FILE_TYPE);
+function getMetaTtl(submissionDocument, graph) {
+  return getPart(submissionDocument, META_FILE_TYPE, graph);
 }
 
 /**
  * Update the additions and removals of the given submission document with the given id
 */
-async function updateDocument(submissionDocument, { additions, removals }) {
-  await saveAdditions(submissionDocument, additions);
-  await saveRemovals(submissionDocument, removals);
+async function updateDocument(submissionDocument, { additions, removals }, graph) {
+  await saveAdditions(submissionDocument, additions, graph);
+  await saveRemovals(submissionDocument, removals, graph);
 }
 
 /**
  * Write the form data to a TTL on disk.
  * The TTL will be used to render the form in the frontend.
  */
-async function saveFormTriples(submissionDocument, triples) {
+async function saveFormTriples(submissionDocument, triples, graph) {
   const nt = triples.map(t => t.toNT()).join('\n');
-  const file = await saveFormData(submissionDocument, nt);
+  const file = await saveFormData(submissionDocument, nt, graph);
   return file;
 }
 
@@ -86,14 +86,14 @@ export {
  * @param {string} submissionDocument URI of the submitted document to get the harvested data for
  * @return {string} TTL with harvested data for the given submission document
 */
-async function getHarvestedData(submissionDocument) {
+async function getHarvestedData(submissionDocument, graph) {
   const result = await query(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
     SELECT DISTINCT ?physicalFile
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
         ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
         ?physicalFile nie:dataSource ?logicalFile .
@@ -114,8 +114,8 @@ async function getHarvestedData(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the additions for
  * @return {string} TTL with additions for the given submission document
 */
-function getAdditions(submissionDocument) {
-  return getPart(submissionDocument, ADDITIONS_FILE_TYPE);
+function getAdditions(submissionDocument, graph) {
+  return getPart(submissionDocument, ADDITIONS_FILE_TYPE, graph);
 }
 
 /**
@@ -125,8 +125,8 @@ function getAdditions(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the removals for
  * @return {string} TTL with removals for the given submission document
 */
-function getRemovals(submissionDocument) {
-  return getPart(submissionDocument, REMOVALS_FILE_TYPE);
+function getRemovals(submissionDocument, graph) {
+  return getPart(submissionDocument, REMOVALS_FILE_TYPE, graph);
 }
 
 /**
@@ -136,7 +136,7 @@ function getRemovals(submissionDocument) {
  * @param {string} fileType URI of the type of the related file
  * @return {string} Content of the related file
 */
-async function getPart(submissionDocument, fileType) {
+async function getPart(submissionDocument, fileType, graph) {
   const result = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -144,7 +144,7 @@ async function getPart(submissionDocument, fileType) {
 
     SELECT DISTINCT ?physicalFile
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
         ?physicalFile nie:dataSource ?logicalFile .
       }
@@ -170,7 +170,7 @@ async function getPart(submissionDocument, fileType) {
  * @param {string} fileType URI of the type of the related file
  * @return {string} Content of the related file
 */
-async function getPartNoLogical(submissionDocument, fileType) {
+async function getPartNoLogical(submissionDocument, fileType, graph) {
   const result = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -178,7 +178,7 @@ async function getPartNoLogical(submissionDocument, fileType) {
 
     SELECT DISTINCT ?file
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
       }
 
@@ -202,8 +202,8 @@ async function getPartNoLogical(submissionDocument, fileType) {
  * @param {string} submissionDocument URI of the submitted document to write the additions for
  * @param {string} content Additions on the harvested data in TTL format
 */
-function saveAdditions(submissionDocument, content) {
-  return savePart(submissionDocument, content, ADDITIONS_FILE_TYPE);
+function saveAdditions(submissionDocument, content, graph) {
+  return savePart(submissionDocument, content, ADDITIONS_FILE_TYPE, graph);
 }
 
 /**
@@ -213,8 +213,8 @@ function saveAdditions(submissionDocument, content) {
  * @param {string} submissionDocument URI of the submitted document to write the removals for
  * @param {string} content Removals on the harvested data in TTL format
 */
-function saveRemovals(submissionDocument, content) {
-  return savePart(submissionDocument, content, REMOVALS_FILE_TYPE);
+function saveRemovals(submissionDocument, content, graph) {
+  return savePart(submissionDocument, content, REMOVALS_FILE_TYPE, graph);
 }
 
 /**
@@ -223,8 +223,8 @@ function saveRemovals(submissionDocument, content) {
  * @param {string} submissionDocument URI of the submitted document to write the additions for
  * @param {string} content Additions on the harvested data in TTL format
 */
-function saveFormData(submissionDocument, content) {
-  return savePart(submissionDocument, content, FORM_DATA_FILE_TYPE);
+function saveFormData(submissionDocument, content, graph) {
+  return savePart(submissionDocument, content, FORM_DATA_FILE_TYPE, graph);
 }
 
 /**
@@ -234,7 +234,7 @@ function saveFormData(submissionDocument, content) {
  * @param {string} content Content to write to the file
  * @param {string} fileType URI of the type of the related file
 */
-async function savePart(submissionDocument, content, fileType) {
+async function savePart(submissionDocument, content, fileType, graph) {
   const result = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -242,7 +242,7 @@ async function savePart(submissionDocument, content, fileType) {
 
     SELECT DISTINCT ?file
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(graph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
       }
       ?file dct:type ${sparqlEscapeUri(fileType)} .
@@ -250,18 +250,18 @@ async function savePart(submissionDocument, content, fileType) {
   `);
 
   if (!result.results.bindings.length) {
-    const logicalFileUri = await insertTtlFile(submissionDocument, content);
+    const logicalFileUri = await insertTtlFile(submissionDocument, content, graph);
     await update(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
           ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(graph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
@@ -269,7 +269,7 @@ async function savePart(submissionDocument, content, fileType) {
     return logicalFileUri;
   } else {
     const file = result.results.bindings[0]['file'].value;
-    await updateTtlFile(submissionDocument, file, content);
+    await updateTtlFile(submissionDocument, file, content, graph);
     return file;
   }
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -9,7 +9,7 @@ import * as env from '../env.js';
  * @param string status URI of the new status
  * @param string or undefined URI of the error that needs to be attached
 */
-export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, logicalFileUri) {
+export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, logicalFileUri, graph) {
   const taskUriSparql = mu.sparqlEscapeUri(taskUri);
   const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
@@ -29,14 +29,14 @@ export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, l
   const statusUpdateQuery = `
     ${env.PREFIXES}
     DELETE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
       }
     }
     INSERT {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
           ${resultContainerUuid ? `task:resultsContainer asj:${resultContainerUuid} ;` : ''}
@@ -49,7 +49,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, l
       }
     }
     WHERE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
@@ -59,3 +59,16 @@ export async function updateTaskStatus(taskUri, status, errorUri, extraStatus, l
   await mas.updateSudo(statusUpdateQuery);
 }
 
+export async function getOrganisationIdFromTask(taskUri) {
+  const response = await mas.querySudo(`
+    ${env.PREFIXES}
+    SELECT DISTINCT ?organisationId WHERE {
+      ${mu.sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+      ?job prov:generated ?submission .
+      ?submission pav:createdBy ?bestuurseenheid .
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }
+    LIMIT 1
+  `);
+  return response?.results?.bindings[0]?.organisationId?.value;
+}

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -5,16 +5,19 @@ import { getFormTtl, getSourceTtl, getMetaTtl, updateDocument, saveFormTriples }
 import fs from 'fs';
 import { RemoteDataObject } from './remote-data-object';
 import * as env from '../env.js';
+import * as config from '../config';
 
 const CONCEPT_STATUS = 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
 const SUBMITABLE_STATUS = 'http://lblod.data.gift/concepts/f6330856-e261-430f-b949-8e510d20d0ff';
 const SENT_STATUS = 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c';
 
 class Submission {
-  constructor({uri, status, submittedResource}) {
+  constructor({ uri, status, submittedResource, organisationId }) {
     this.uri = uri;
     this.status = status;
     this.submittedResource = submittedResource; // submission document
+    this.organisationId = organisationId;
+    this.graph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationId);;
   }
 
   async updateStatus(status) {
@@ -22,16 +25,16 @@ class Submission {
       PREFIX adms: <http://www.w3.org/ns/adms#>
 
       DELETE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(this.graph)} {
           ${sparqlEscapeUri(this.uri)} adms:status ?status .
         }
       }
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(this.graph)} {
           ${sparqlEscapeUri(this.uri)} adms:status ${sparqlEscapeUri(status)} .
         }
       } WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(this.graph)} {
           ${sparqlEscapeUri(this.uri)} adms:status ?status .
         }
       }
@@ -42,7 +45,7 @@ class Submission {
    * Updates the additions and removals and processes the form
    */
   async update({additions, removals}) {
-    await updateDocument(this.submittedResource, {additions, removals});
+    await updateDocument(this.submittedResource, {additions, removals}, this.graph);
     await this.process();
   }
 
@@ -51,9 +54,9 @@ class Submission {
    */
   async process() {
     try {
-      const formTtl = await getFormTtl(this.submittedResource);
-      const metaTtl = await getMetaTtl(this.submittedResource);
-      const sourceTtl = await getSourceTtl(this.submittedResource);
+      const formTtl = await getFormTtl(this.submittedResource, this.graph);
+      const metaTtl = await getMetaTtl(this.submittedResource, this.graph);
+      const sourceTtl = await getSourceTtl(this.submittedResource, this.graph);
       const formBuilder = new FormBuilder({submittedResource: this.submittedResource, formTtl, sourceTtl, metaTtl});
       const triples = formBuilder.build().data();
 
@@ -65,7 +68,7 @@ class Submission {
       const isValid = formBuilder.validate();
       console.log(`Form for submitted resource ${this.submittedResource} is valid: ${isValid}`);
 
-      const currentStatus = await getSubmissionStatus(this.uri);
+      const currentStatus = await getSubmissionStatus(this.uri, this.graph);
       if (!currentStatus)
         throw new Error(`Submission <${this.uri}> doesn't have a status`);
 
@@ -79,12 +82,12 @@ class Submission {
           console.log(`Updating status of submission ${this.uri} to sent state since it's valid`);
           await this.submit(formBuilder.form.value, triples);
           // NOTE find and save/update remote-data-objects
-          await RemoteDataObject.process(triples);
+          await RemoteDataObject.process(triples, this.graph);
           targetStatus = SENT_STATUS;
         }
       }
 
-      const logicalFileUri = await saveFormTriples(this.submittedResource, triples);
+      const logicalFileUri = await saveFormTriples(this.submittedResource, triples, this.graph);
 
       if (targetStatus) {
         await this.updateStatus(targetStatus);
@@ -111,12 +114,12 @@ class Submission {
           PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
 
           INSERT {
-            GRAPH ?g {
+            GRAPH ${sparqlEscapeUri(this.graph)} {
               ${sparqlEscapeUri(this.uri)} prov:used ${sparqlEscapeUri(formUri)} ;
                                         nmo:sentDate ${sparqlEscapeDateTime(timestamp)} .
             }
           } WHERE {
-            GRAPH ?g {
+            GRAPH ${sparqlEscapeUri(this.graph)} {
               ${sparqlEscapeUri(this.uri)} a meb:Submission .
             }
           }
@@ -130,10 +133,10 @@ class Submission {
   }
 }
 
-async function getSubmissionByTask(taskUri) {
+async function getSubmissionByTask(taskUri, reqState) {
   const response = await query(`
     ${env.PREFIXES}
-    SELECT ?submission ?submissionDocument ?status
+    SELECT ?submission ?submissionDocument ?status ?organisationId
     WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(taskUri)}
@@ -142,8 +145,10 @@ async function getSubmissionByTask(taskUri) {
         ?job prov:generated ?submission .
         ?submission
           dct:subject ?submissionDocument ;
-          adms:status ?status .
+          adms:status ?status ;
+          pav:createdBy ?bestuurseenheid .
       }
+      ?bestuurseenheid mu:uuid ?organisationId .
     } LIMIT 1
   `);
 
@@ -153,27 +158,24 @@ async function getSubmissionByTask(taskUri) {
     return new Submission({
       uri: binding.submission.value,
       status: binding.status.value,
-      submittedResource: binding.submissionDocument.value
+      submittedResource: binding.submissionDocument.value,
+      organisationId: binding.organisationId.value,
     });
   }
 }
 
 async function getSubmissionBySubmissionDocument(uuid) {
   const result = await query(`
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-    PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-
-    SELECT ?submission ?submissionDocument ?status
+    ${env.PREFIXES}
+    SELECT ?submission ?submissionDocument ?status ?organisationId
     WHERE {
       GRAPH ?g {
         ?submissionDocument mu:uuid ${sparqlEscapeString(uuid)} .
         ?submission dct:subject ?submissionDocument ;
-                    adms:status ?status .
+                    adms:status ?status ;
+                    pav:createdBy ?bestuurseenheid .
       }
+      ?bestuurseenheid mu:uuid ?organisationId .
     } LIMIT 1
   `);
 
@@ -182,19 +184,24 @@ async function getSubmissionBySubmissionDocument(uuid) {
     return new Submission({
       uri: binding['submission'].value,
       status: binding['status'].value,
-      submittedResource: binding['submissionDocument'].value
+      submittedResource: binding['submissionDocument'].value,
+      organisationId: binding.organisationId.value,
     });
   } else {
     return null;
   }
 }
 
-async function getSubmissionStatus(submissionUri) {
+async function getSubmissionStatus(submissionUri, graph) {
   const result = await query(`
   PREFIX adms: <http://www.w3.org/ns/adms#>
 
   SELECT ?status
-  WHERE { ${sparqlEscapeUri(submissionUri)} adms:status ?status . }
+  WHERE {
+    GRAPH ${sparqlEscapeUri(graph)} {
+      ${sparqlEscapeUri(submissionUri)} adms:status ?status .
+    }
+  }
   LIMIT 1
 `);
 

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -136,7 +136,7 @@ class Submission {
 async function getSubmissionByTask(taskUri, reqState) {
   const response = await query(`
     ${env.PREFIXES}
-    SELECT ?submission ?submissionDocument ?status ?organisationId
+    SELECT ?submission ?submissionDocument ?status
     WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(taskUri)}
@@ -145,10 +145,8 @@ async function getSubmissionByTask(taskUri, reqState) {
         ?job prov:generated ?submission .
         ?submission
           dct:subject ?submissionDocument ;
-          adms:status ?status ;
-          pav:createdBy ?bestuurseenheid .
+          adms:status ?status .
       }
-      ?bestuurseenheid mu:uuid ?organisationId .
     } LIMIT 1
   `);
 
@@ -159,7 +157,7 @@ async function getSubmissionByTask(taskUri, reqState) {
       uri: binding.submission.value,
       status: binding.status.value,
       submittedResource: binding.submissionDocument.value,
-      organisationId: binding.organisationId.value,
+      organisationId: reqState.organisationId,
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "@lblod/mu-auth-sudo": "^0.2.0",
     "@lblod/submission-form-helpers": "^1.3.0",
     "body-parser": "1.19.0",
+    "env-var": "^7.3.0",
     "forking-store": "^1.0.0",
     "fs-extra": "^8.1.0",
     "lodash.flatten": "^4.4.0",
     "moment": "^2.24.0",
     "rdflib": "1.1.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
In order to improve data security, the services in the automatic submission flow should only insert data in one specific controlled graph.

This fixes issues related to data spreading in graphs that should not contain that data. More specific for the vendor-data-distribution-service.

This PR includes a configuration file where the graph template is loaded from environment variables, but with sensible defaults so that nothing special should be done in most cases. The code is adapted to always compute the graph from the template in combination with the organisation ID before inserting into the triplestore.