### PR TITLE
[DL-6006] Add the `DecisionArticles` validator

### DIFF
--- a/lib/field-validators/decision-articles.js
+++ b/lib/field-validators/decision-articles.js
@@ -1,0 +1,65 @@
+import { registerCustomValidation } from '@lblod/submission-form-helpers';
+import { Literal, NamedNode, Namespace } from 'rdflib';
+
+const ELI = new Namespace('http://data.europa.eu/eli/ontology#');
+const refersTo = ELI('refers_to');
+const documentType = ELI('type_document');
+
+export function registerDecisionArticlesValidator() {
+  registerCustomValidation(
+    'http://lblod.data.gift/vocabularies/forms/DecisionArticlesValidator',
+    // This validator assumes a form:Bag grouping with the `sh:path` set to `eli:has_part`
+    // Keep this in sync with the frontend version: https://github.com/lblod/frontend-loket/blob/11d440cb94d24f26b16a5774ad02d55b83b401dd/app/components/supervision/decision-articles-field.gjs#L906-L944
+    (articles, options) => {
+      if (articles.length === 0) {
+        return false;
+      }
+
+      const { constraintUri, formGraph, store, sourceGraph } = options;
+
+      const areArticlesValid = articles
+        .map((articleNode) => {
+          const documents = store.match(
+            articleNode,
+            refersTo,
+            undefined,
+            sourceGraph,
+          );
+
+          if (documents.length === 0) {
+            return false;
+          }
+
+          const isTypeOptional = isDocumentTypeOptional(
+            store,
+            constraintUri,
+            formGraph,
+          );
+
+          if (isTypeOptional) {
+            return true;
+          }
+
+          const type = store.any(articleNode, documentType, undefined, sourceGraph);
+
+          return Boolean(type);
+        })
+        .every(Boolean);
+
+      return areArticlesValid;
+    }
+  );
+}
+
+function isDocumentTypeOptional(store, node, formGraph) {
+  const literal = store.any(
+    node,
+    new NamedNode(
+      'http://lblod.data.gift/vocabularies/form-field-options/exclude-type_document',
+    ),
+    undefined,
+    formGraph,
+  );
+
+  return typeof literal !== 'undefined' && literal !== null && Literal.toJS(literal);
+}

--- a/lib/form-builder.js
+++ b/lib/form-builder.js
@@ -1,8 +1,7 @@
 import { NamedNode, graph as rdflibGraph, parse as rdflibParse } from 'rdflib';
-import { RDF, FORM, SHACL } from '@lblod/submission-form-helpers';
-import { importTriplesForForm, fieldsForForm, validateForm, validateField } from '@lblod/submission-form-helpers';
-import { check } from '@lblod/submission-form-helpers';
-import fs from 'fs';
+import { RDF, FORM } from '@lblod/submission-form-helpers';
+import { importTriplesForForm, validateForm } from '@lblod/submission-form-helpers';
+import { registerDecisionArticlesValidator } from './field-validators/decision-articles';
 
 const FORM_GRAPH = 'http://data.lblod.info/graphs/semantic-forms';
 const META_GRAPH = 'http://data.lblod.info/graphs/meta';
@@ -18,6 +17,8 @@ class FormBuilder {
     rdflibParse(sourceTtl, this.store, SOURCE_GRAPH, 'text/turtle');
 
     this._submittedResource = submittedResource;
+
+    registerDecisionArticlesValidator();
   }
 
   get formGraph() {


### PR DESCRIPTION
This ensures we use the same validations as the frontend. We simply copy paste the implementation for now since it is unlikely to change much once it is stable and it allows us to do extra things in the backend version if needed.

Related PRs: 
- https://github.com/lblod/frontend-loket/pull/391
- https://github.com/lblod/app-digitaal-loket/pull/575 

Builds on #11 so that needs to be merged first.

### Test instructions

#### Setup
Run this https://github.com/lblod/app-digitaal-loket/pull/605 branch locally and add the following config to your docker-compose.override.yml of your app-digitaal-loket app to test this feature.

```yml filename=
  validate-submission:
    image: lblod/validate-submission-service:feature-decisions-article-validator
```

This one is a bit tricky to test since we also use the validator in the frontend, and the frontend will only call the backend if there are no errors there.

#### 2 options

##### 1: Modify the frontend (easiest)
1. Run the frontend locally and temporarily disable the registration of the custom validator by commenting [these lines](https://github.com/lblod/frontend-loket/blob/427a8103536e1ae4deb4ac76373c9bfbcd2aea36/app/components/supervision/fields/decision-articles-field.gjs#L591-L594).
2. Fill in the form as normal but leave the "Artikels" field empty and submit.
3. The submit call should respond with a 400 "Unable to submit form" response
    -  Note: The frontend doesn't seem to handle the case where the submit call fails properly, so it still acts as if everything is ok. It will redirect to the overview page. The network tab will show the 400 response though. 
5. Add some documents so the artikel field is valid and submit again
6. This should now work properly

##### 2: forge the submit call manually
1. Don't use the frontend to submit. Fill in the form as normal but leave the "Artikels" field empty and only use the "bewaar als concept" button. This will persist the form state to the backend but won't try to submit it.
2. Once saved you can then execute an api call to start the submission process. 
3. `POST /submission-forms/[your-submission-document-id-here]/submit` should return a 400 "Unable to submit form" response.
    - You can find the id by looking at the data tab in the ember inspector and looking for the submission-document that corresponds to the form.
5. Add some documents so the "artikel" field is valid, and save as concept again
6. Run the API call again and it should submit successfully this time.
7. It's possible the UI state isn't 100% correct if you go this route, since the frontend does some extra api calls when submitting. I haven't tested this method.