### PR TITLE
Implement fix referencing between Gemeente - CKB - EB

### DIFF
--- a/lib/submission.js
+++ b/lib/submission.js
@@ -160,13 +160,34 @@ class Submission {
             if (isCKBRelevant) {
               const ckbUri = await ab.getRelatedCKB(referredOrg);
               const ckbType = await ab.getOrganisationType(ckbUri);
+              const ckbExpectedDocumentType =
+                await uti.getCrossReferencingChildType(
+                  crossReference.documentType,
+                  referrerType,
+                  ckbType,
+                );
+              // Find the document from the CKB that refers to the document from the EB
+              const referredCKBDocument =
+                await findCKBDocumentReferringToEBDocument(
+                  crossReference.referredDocument,
+                  crossReference.referredDocumentType,
+                  ckbExpectedDocumentType,
+                  referredOrg,
+                  ckbUri,
+                );
+              const referredCKBDocumentType =
+                await getDocumentTypeFromTriplestore(referredCKBDocument);
 
-              const predictedChildType = await uti.getCrossReferencingChildType(
-                crossReference.documentType,
-                referrerType,
-                ckbType,
-              );
-              if (predictedChildType !== crossReference.referredDocumentType) {
+              const ebExpectedDocumentType =
+                await uti.getCrossReferencingChildType(
+                  referredCKBDocumentType,
+                  ckbType,
+                  referredOrgType,
+                );
+              if (
+                referredCKBDocumentType !== ckbExpectedDocumentType ||
+                crossReference.referredDocumentType !== ebExpectedDocumentType
+              ) {
                 isValidCrossReferencing = false;
                 break;
               }
@@ -418,6 +439,52 @@ async function getDocumentTypeFromTriplestore(documentUri) {
   if (result?.results?.bindings) {
     return result.results.bindings.map(
       (binding) => binding.documentType.value,
+    )[0];
+  }
+}
+
+async function findCKBDocumentReferringToEBDocument(
+  ebDocument,
+  ebDocumentType,
+  ckbDocumentType,
+  eb,
+  ckb,
+) {
+  const response = await query(`
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+    PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX pav: <http://purl.org/pav/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+    SELECT DISTINCT ?ckbDocument
+    WHERE {
+      ?betrokkenBestuur org:organization ${sparqlEscapeUri(eb)} .
+      ?eenheid ere:betrokkenBestuur ?betrokkenBestuur .
+      ${sparqlEscapeUri(ckb)} org:hasSubOrganization ?eredienst.
+
+      ?ckbSubmission
+        a meb:Submission ;
+        dcterms:subject ?ckbDocument ;
+        pav:createdBy ${sparqlEscapeUri(ckb)} ;
+        prov:generated ?formData .
+
+      ?formData
+        ext:decisionType ${sparqlEscapeUri(ckbDocumentType)} ;
+        dcterms:relation ${sparqlEscapeUri(ebDocument)} .
+
+      ?ebSubmission
+        dcterms:subject ${sparqlEscapeUri(ebDocument)} ;
+        pav:createdBy ${sparqlEscapeUri(eb)} ;
+        prov:generated ?ebFormData .
+
+      ?ebFormData ext:decisionType ${sparqlEscapeUri(ebDocumentType)} .
+    }`);
+  if (response?.results?.bindings) {
+    return response.results.bindings.map(
+      (binding) => binding.ckbDocument.value,
     )[0];
   }
 }


### PR DESCRIPTION
A Gemeente document wants to refer to the document from the EB, no matter if a CKB sits in between. But we still have to check the existence, and validity of the document types between the Gemeente and the CKB, AND between the CKB and the EB.