### PR TITLE
 Fix crash when referred organisation has no active CKB

### DIFF
--- a/lib/submission.js
+++ b/lib/submission.js
@@ -157,8 +157,12 @@ class Submission {
             const isCKBRelevant = await ab.isCKBRelevantForDecisionType(
               crossReference.documentType,
             );
+            let ckbUri;
             if (isCKBRelevant) {
-              const ckbUri = await ab.getRelatedCKB(referredOrg);
+              ckbUri = await ab.getRelatedCKB(referredOrg);
+            }
+
+            if (ckbUri) {
               const ckbType = await ab.getOrganisationType(ckbUri);
               const ckbExpectedDocumentType =
                 await uti.getCrossReferencingChildType(


### PR DESCRIPTION
 When getRelatedCKB returns null (erediensten without an active
 Centraal Bestuur, e.g. Protestantse kerken, or when the
 reorg:orgStatus doesn't match the hardcoded concept),
 getOrganisationType was called with null, crashing sparqlEscapeUri.
See also: 
  - https://binnenland.atlassian.net/browse/DL-7456
  - https://binnenland.atlassian.net/browse/DL-7450

TODO: update CHANGELOG.md and properly deploy everywhere.