### PR TITLE
Set status, sentDate and modified in one update

### DIFF
--- a/lib/submission.js
+++ b/lib/submission.js
@@ -236,6 +236,7 @@ class Submission {
         throw new Error(`Submission <${this.uri}> doesn't have a status`);
 
       let targetStatus = null;
+      let formUri = null;
 
       if (currentStatus === SUBMITABLE_STATUS) {
         if (!isValid || !isValidCrossReferencing) {
@@ -247,10 +248,10 @@ class Submission {
           console.log(
             `Updating status of submission ${this.uri} to sent state since it's valid`,
           );
-          await this.submit(formBuilder.form.value, triples);
           // NOTE find and save/update remote-data-objects
           await RemoteDataObject.process(triples, this.graph);
           targetStatus = SENT_STATUS;
+          formUri = formBuilder.form.value;
         }
       }
 
@@ -260,7 +261,9 @@ class Submission {
         this.graph,
       );
 
-      if (targetStatus) {
+      if (targetStatus === SENT_STATUS) {
+        await this.markSent(formUri);
+      } else if (targetStatus) {
         await this.updateStatus(targetStatus);
       }
 
@@ -278,25 +281,32 @@ class Submission {
   }
 
   /**
-   * Submit a valid submission
-   * - keep a reference to the form used to fill in form
+   * Atomically set status to 'sent' with prov:used and nmo:sentDate, guarded on
+   * the existing adms:status so status and sentDate can't diverge.
    */
-  async submit(formUri) {
+  async markSent(formUri) {
     try {
       const timestamp = new Date();
       const q = `
-          PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+          PREFIX adms: <http://www.w3.org/ns/adms#>
           PREFIX prov: <http://www.w3.org/ns/prov#>
           PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+          PREFIX dct: <http://purl.org/dc/terms/>
 
+          DELETE {
+            GRAPH ${sparqlEscapeUri(this.graph)} {
+              ${sparqlEscapeUri(this.uri)} adms:status ?status .
+            }
+          }
           INSERT {
             GRAPH ${sparqlEscapeUri(this.graph)} {
-              ${sparqlEscapeUri(this.uri)} prov:used ${sparqlEscapeUri(formUri)} ;
+              ${sparqlEscapeUri(this.uri)} adms:status ${sparqlEscapeUri(SENT_STATUS)} ;
+                                        prov:used ${sparqlEscapeUri(formUri)} ;
                                         nmo:sentDate ${sparqlEscapeDateTime(timestamp)} .
             }
           } WHERE {
             GRAPH ${sparqlEscapeUri(this.graph)} {
-              ${sparqlEscapeUri(this.uri)} a meb:Submission .
+              ${sparqlEscapeUri(this.uri)} adms:status ?status .
             }
           }
         `;


### PR DESCRIPTION
adms:status and nmo:sentDate were written by two separate SPARQL updates, so a failure in between could leave a submission with a sentDate but an unchanged status. Fold both into a single atomic update, alongside prov:used and a refreshed dct:modified.